### PR TITLE
Converted to babel with ES6 standard and updated the color package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,3 @@
 {
-  "plugins": [
-    "transform-object-rest-spread"
-  ]
+  "presets": ["env"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Skip yarn.lock and rely on package-lock.json from npm
+yarn.lock

--- a/build/errors.js
+++ b/build/errors.js
@@ -1,8 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 /**
  * Stupid error collections
  */
 
-exports.NO_EDN_FRAC = new Error('The last element in the color array should not have a frac field');
-exports.MIN_ARRAY_LENGTH = new Error('Color array length must > 1');
-exports.FRAC_SUM_ERROR = new Error('The sum of the fracs should = 1');
-exports.COLOR_NUMBER_ERROR = new Error('The number of generated colors should >= the number of color stops');
+var NO_EDN_FRAC = exports.NO_EDN_FRAC = new Error('The last element in the color array should not have a frac field');
+var MIN_ARRAY_LENGTH = exports.MIN_ARRAY_LENGTH = new Error('Color array length must > 1');
+var FRAC_SUM_ERROR = exports.FRAC_SUM_ERROR = new Error('The sum of the fracs should = 1');
+var COLOR_NUMBER_ERROR = exports.COLOR_NUMBER_ERROR = new Error('The number of generated colors should >= the number of color stops');

--- a/build/index.js
+++ b/build/index.js
@@ -1,62 +1,70 @@
-const Color = require('color');
-const {
-  NO_EDN_FRAC,
-  MIN_ARRAY_LENGTH,
-  FRAC_SUM_ERROR,
-  COLOR_NUMBER_ERROR
-} = require('./errors');
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _color = require('color');
+
+var _color2 = _interopRequireDefault(_color);
+
+var _errors = require('./errors');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
  * Generate n colors with given color stops
- * 
- * @param   {Array}  colorArray 
- * @param   {Number} n          number of colors that need to generate 
+ *
+ * @param   {Array}  colorArray
+ * @param   {Number} n          number of colors that need to generate
  * @returns {Array} array of generated colors in rgb mode
  */
 
 function gradient(colorArray, n) {
-  const isFullOption = checkParam(colorArray, n);
+  var isFullOption = checkParam(colorArray, n);
 
   // init 2 arrays for algorithm
-  let colorList = [];
-  let fracList = [];
+  var colorList = [];
+  var fracList = [];
   // result array for storing data
-  let resultArray = [];
+  var resultArray = [];
 
   // simple array of color string
   if (!isFullOption) {
-    const frac = 1 / (colorArray.length - 1);
+    var frac = 1 / (colorArray.length - 1);
 
-    colorArray.forEach((colorString, index) => {
+    colorArray.forEach(function (colorString, index) {
       if (index !== colorArray.length - 1) {
-        colorList.push(Color(colorString));
+        colorList.push((0, _color2.default)(colorString));
         fracList.push(frac);
       } else {
-        colorList.push(Color(colorString));
+        colorList.push((0, _color2.default)(colorString));
       }
     });
   } else {
-    colorArray.forEach((obj, index) => {
+    colorArray.forEach(function (obj, index) {
       if (index !== colorArray.length - 1) {
-        colorList.push(Color(obj.color));
+        colorList.push((0, _color2.default)(obj.color));
         fracList.push(obj.frac);
       } else {
         if (obj.color) {
           // the last item could be like { color: #ffffff }
-          colorList.push(Color(obj.color));
+          colorList.push((0, _color2.default)(obj.color));
         } else {
           // and it could also be like '#ffffff'
-          colorList.push(Color(obj));
+          colorList.push((0, _color2.default)(obj));
         }
       }
     });
   }
 
-  const assignList = assignNumbers(fracList, n);
+  var assignList = assignNumbers(fracList, n);
   resultArray = createGradient(colorList, assignList);
 
   // convert colors to string version
-  resultArray = resultArray.map(c => c.rgb().toString());
+  resultArray = resultArray.map(function (c) {
+    return c.rgb().toString();
+  });
 
   return resultArray;
 }
@@ -65,25 +73,25 @@ function gradient(colorArray, n) {
  * Explainations:
  * o -> stop color for gradient
  * * -> generated color
- * 
+ *
  * o * * * | o * * * * | o * * o -> generated color list in char version
  *    4          5          4    -> assigned number of colors need to be generated
- * 
+ *
  * The last section, the end color should be considered in the generated colors
- * 
+ *
  * @returns {Array} array of colors in Color(pkg) format, need toString() call
  */
 
 function createGradient(colorList, assignList) {
-  let result = [];
+  var result = [];
 
-  assignList.forEach((num, index) => {
-    const isLastElement = index === assignList.length - 1;
-    const list = [];
+  assignList.forEach(function (num, index) {
+    var isLastElement = index === assignList.length - 1;
+    var list = [];
 
     // get end point color
-    const start = colorList[index];
-    const end = colorList[index + 1];
+    var start = colorList[index];
+    var end = colorList[index + 1];
 
     // if last element, end color should be in the list,
     // so the num = num - 1
@@ -91,17 +99,17 @@ function createGradient(colorList, assignList) {
       num = num - 1;
     }
 
-    const deltaR = (end.red() - start.red()) / num;
-    const deltaG = (end.green() - start.green()) / num;
-    const deltaB = (end.blue() - start.blue()) / num;
+    var deltaR = (end.red() - start.red()) / num;
+    var deltaG = (end.green() - start.green()) / num;
+    var deltaB = (end.blue() - start.blue()) / num;
 
     // generate num colors
-    for (let i = 0; i < num; i++) {
-      const R = start.red() + i * deltaR;
-      const G = start.green() + i * deltaG;
-      const B = start.blue() + i * deltaB;
+    for (var i = 0; i < num; i++) {
+      var R = start.red() + i * deltaR;
+      var G = start.green() + i * deltaG;
+      var B = start.blue() + i * deltaB;
 
-      list.push(Color.rgb(R, G, B));
+      list.push(_color2.default.rgb(R, G, B));
     }
 
     // if last element, end this list with the last color
@@ -117,35 +125,35 @@ function createGradient(colorList, assignList) {
 
 /**
  * Calculate and optimize the number of each color period
- * 
+ *
  * Sometimes frac * N might be a fraction
  * So we use this algorithm:
- * 
+ *
  * 1. Split the number into 2 parts, each part fits in an array:
  * [2, 4, 1, 5]         -> int array
  * [0.2, 0.5, 0.9, 0.3] -> decimal array
- * 
+ *
  * The left number should be:
  * left = N - sum(intArray)
- * 
+ *
  * 2. Sort the decimal array from large to small, assign left to
  * the corresponding element in intArray one by one
  * until left === 0
- * 
+ *
  * 3. There goes your final array!
- * 
+ *
  * @returns {Array} array of optimized color numbers
  */
 
 function assignNumbers(fracList, n) {
-  const intArray = [];
-  const decimalArray = [];
+  var intArray = [];
+  var decimalArray = [];
 
   // assign int part
-  fracList.forEach((frac, index) => {
-    const real = frac * n;
-    const intPart = Math.floor(real);
-    const decimalPart = real - intPart;
+  fracList.forEach(function (frac, index) {
+    var real = frac * n;
+    var intPart = Math.floor(real);
+    var decimalPart = real - intPart;
 
     intArray.push(intPart);
     decimalArray.push({
@@ -155,15 +163,19 @@ function assignNumbers(fracList, n) {
   });
 
   // how many left ?
-  const left = n - intArray.reduce((a, b) => a + b, 0);
+  var left = n - intArray.reduce(function (a, b) {
+    return a + b;
+  }, 0);
 
   // sort O -> o
-  decimalArray.sort((a, b) => b.value - a.value);
+  decimalArray.sort(function (a, b) {
+    return b.value - a.value;
+  });
 
   // assign the left number regard to the decimal part's value
   // until nothing left
-  for (let i = 0; i < left; i++) {
-    const targetIndex = decimalArray[i].index;
+  for (var i = 0; i < left; i++) {
+    var targetIndex = decimalArray[i].index;
     intArray[targetIndex] = intArray[targetIndex] + 1;
   }
 
@@ -177,28 +189,30 @@ function assignNumbers(fracList, n) {
 function checkParam(array, n) {
   // Seriously? Anyone this dumb?
   if (array.length < 2) {
-    throw MIN_ARRAY_LENGTH;
+    throw _errors.MIN_ARRAY_LENGTH;
   }
 
   // Read the documentation OMG! Of course no frac at the end!
   if (array[array.length - 1].frac) {
-    throw NO_EDN_FRAC;
+    throw _errors.NO_EDN_FRAC;
   }
 
   // You need to see a doctor, like, right now
   if (n <= array.length) {
-    throw COLOR_NUMBER_ERROR;
+    throw _errors.COLOR_NUMBER_ERROR;
   }
 
   // if full option mode, sum should be 1
   if (typeof array[0] !== 'string') {
-    const fracSum = array.slice(0, array.length - 1).reduce((a, b) => a + b.frac, 0);
+    var fracSum = array.slice(0, array.length - 1).reduce(function (a, b) {
+      return a + b.frac;
+    }, 0);
     if (fracSum < 0.99) {
-      throw FRAC_SUM_ERROR;
+      throw _errors.FRAC_SUM_ERROR;
     }
   }
 
-  let result;
+  var result = void 0;
 
   if (typeof array[0] === 'string') {
     result = false;
@@ -209,4 +223,4 @@ function checkParam(array, n) {
   return result;
 }
 
-module.exports = gradient;
+exports.default = gradient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,16 +2,17 @@
   "name": "gradient-color",
   "version": "2.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
@@ -20,14 +21,21 @@
       "resolved": "http://registry.npm.taobao.org/anymatch/download/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -38,7 +46,7 @@
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "http://registry.npm.taobao.org/array-unique/download/array-unique-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true,
       "optional": true
@@ -52,7 +60,7 @@
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/async-each/download/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true,
       "optional": true
@@ -61,85 +69,642 @@
       "version": "6.24.1",
       "resolved": "http://registry.npm.taobao.org/babel-cli/download/babel-cli-6.24.1.tgz",
       "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.6",
+        "v8flags": "2.1.1"
+      }
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "http://registry.npm.taobao.org/babel-code-frame/download/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-core": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-core/download/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-generator": "6.25.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      }
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-generator/download/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "http://registry.npm.taobao.org/babel-helpers/download/babel-helpers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
-    "babel-plugin-syntax-object-rest-spread": {
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-object-rest-spread/download/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "http://registry.npm.taobao.org/babel-polyfill/download/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.9.1",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      }
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "http://registry.npm.taobao.org/babel-register/download/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.25.0",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.15"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "http://registry.npm.taobao.org/babel-runtime/download/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-template": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-template/download/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-types/download/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.4",
@@ -149,7 +714,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -162,45 +727,97 @@
     },
     "blue-tape": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/blue-tape/download/blue-tape-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/blue-tape/-/blue-tape-1.0.0.tgz",
       "integrity": "sha1-dYHQTAc5XJXEJrLtbR7bRUp2uSs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tape": "4.6.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": "http://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "http://registry.npm.taobao.org/braces/download/braces-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "browserslist": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
+      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000772",
+        "electron-to-chromium": "1.3.27"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000772",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000772.tgz",
+      "integrity": "sha1-eBKWIsq/7Xrx/zi2SraApqCGVCA=",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "http://registry.npm.taobao.org/chokidar/download/chokidar-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "color": {
       "version": "1.0.3",
       "resolved": "http://registry.npm.taobao.org/color/download/color-1.0.3.tgz",
-      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0="
+      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+      "requires": {
+        "color-convert": "1.9.0",
+        "color-string": "1.5.2"
+      }
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o="
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "color-name": {
       "version": "1.1.2",
@@ -209,18 +826,25 @@
     },
     "color-string": {
       "version": "1.5.2",
-      "resolved": "http://registry.npm.taobao.org/color-string/download/color-string-1.5.2.tgz",
-      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k="
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+      "requires": {
+        "color-name": "1.1.2",
+        "simple-swizzle": "0.2.2"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -238,7 +862,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "optional": true
@@ -247,114 +871,163 @@
       "version": "2.6.8",
       "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/deep-equal/download/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/define-properties/download/define-properties-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/defined/download/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "http://registry.npm.taobao.org/detect-indent/download/detect-indent-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "es-abstract": {
       "version": "1.7.0",
       "resolved": "http://registry.npm.taobao.org/es-abstract/download/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "resolved": "http://registry.npm.taobao.org/es-to-primitive/download/es-to-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "http://registry.npm.taobao.org/esutils/download/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npm.taobao.org/expand-range/download/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "http://registry.npm.taobao.org/filename-regex/download/filename-regex-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true,
       "optional": true
     },
     "fill-range": {
       "version": "2.2.3",
-      "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "for-each": {
       "version": "0.3.2",
-      "resolved": "http://registry.npm.taobao.org/for-each/download/for-each-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/for-in/download/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true,
       "optional": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "http://registry.npm.taobao.org/for-own/download/for-own-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "http://registry.npm.taobao.org/foreach/download/foreach-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
@@ -366,666 +1039,9 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/fsevents/download/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.0",
@@ -1037,20 +1053,35 @@
       "version": "7.1.2",
       "resolved": "http://registry.npm.taobao.org/glob/download/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "http://registry.npm.taobao.org/glob-base/download/glob-base-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/glob-parent/download/glob-parent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1060,7 +1091,7 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "http://registry.npm.taobao.org/graceful-fs/download/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
@@ -1072,51 +1103,71 @@
     },
     "has": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/has/download/has-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/home-or-tmp/download/home-or-tmp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://registry.npm.taobao.org/inflight/download/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "http://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "invariant": {
       "version": "2.2.2",
-      "resolved": "http://registry.npm.taobao.org/invariant/download/invariant-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "is-arrayish": {
       "version": "0.3.1",
-      "resolved": "http://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
       "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -1126,105 +1177,123 @@
     },
     "is-callable": {
       "version": "1.1.3",
-      "resolved": "http://registry.npm.taobao.org/is-callable/download/is-callable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/is-date-object/download/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "http://registry.npm.taobao.org/is-dotfile/download/is-dotfile-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true,
       "optional": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "http://registry.npm.taobao.org/is-equal-shallow/download/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true,
       "optional": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/is-extglob/download/is-extglob-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/is-finite/download/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-function": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/is-function/download/is-function-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
       "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
       "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "http://registry.npm.taobao.org/is-posix-bracket/download/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true,
       "optional": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/is-primitive/download/is-primitive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "http://registry.npm.taobao.org/is-regex/download/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/is-symbol/download/is-symbol-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "http://registry.npm.taobao.org/isobject/download/isobject-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -1234,88 +1303,111 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lodash": {
       "version": "4.17.4",
-      "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
-      "resolved": "http://registry.npm.taobao.org/loose-envify/download/loose-envify-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-2.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "http://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.6.2",
-      "resolved": "http://registry.npm.taobao.org/nan/download/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-      "dev": true,
-      "optional": true
-    },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "http://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
@@ -1327,57 +1419,75 @@
     },
     "object-keys": {
       "version": "1.0.11",
-      "resolved": "http://registry.npm.taobao.org/object-keys/download/object-keys-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "http://registry.npm.taobao.org/object.omit/download/object.omit-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/os-homedir/download/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/os-tmpdir/download/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "output-file-sync": {
       "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/output-file-sync/download/output-file-sync-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "http://registry.npm.taobao.org/parse-glob/download/parse-glob-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "http://registry.npm.taobao.org/preserve/download/preserve-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true,
       "optional": true
@@ -1390,7 +1500,7 @@
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "http://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true,
       "optional": true
@@ -1401,6 +1511,10 @@
       "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
@@ -1432,14 +1546,35 @@
       "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.0.tgz",
       "integrity": "sha1-ZA9dzaiMkajcYHhxRWKRcIE6HtI=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.0",
+        "string_decoder": "1.0.2",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "http://registry.npm.taobao.org/readdirp/download/readdirp-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.0",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.10.5",
@@ -1447,12 +1582,53 @@
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
       "dev": true
     },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "private": "0.1.7"
+      }
+    },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "http://registry.npm.taobao.org/regex-cache/download/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "1.3.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -1463,22 +1639,25 @@
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/repeat-element/download/repeat-element-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://registry.npm.taobao.org/repeat-string/download/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true,
       "optional": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://registry.npm.taobao.org/repeating/download/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "resolve": {
       "version": "1.1.7",
@@ -1488,9 +1667,12 @@
     },
     "resumer": {
       "version": "0.0.0",
-      "resolved": "http://registry.npm.taobao.org/resumer/download/resumer-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.0",
@@ -1499,21 +1681,30 @@
       "dev": true,
       "optional": true
     },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/set-immediate-shim/download/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true,
       "optional": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "http://registry.npm.taobao.org/simple-swizzle/download/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo="
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "0.3.1"
+      }
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/slash/download/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
@@ -1527,7 +1718,21 @@
       "version": "0.4.15",
       "resolved": "http://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "1.1.0"
+      }
     },
     "string_decoder": {
       "version": "1.0.2",
@@ -1535,6 +1740,9 @@
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      },
       "dependencies": {
         "safe-buffer": {
           "version": "5.0.1",
@@ -1545,21 +1753,18 @@
         }
       }
     },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/string.prototype.trim/download/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
@@ -1568,6 +1773,21 @@
       "resolved": "http://registry.npm.taobao.org/tape/download/tape-4.6.3.tgz",
       "integrity": "sha1-Y353WB6ass4XV36b1M5PV1gG2LY=",
       "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.2.2",
+        "resolve": "1.1.7",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1579,44 +1799,47 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npm.taobao.org/through/download/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "http://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/trim-right/download/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "user-home": {
       "version": "1.1.1",
-      "resolved": "http://registry.npm.taobao.org/user-home/download/user-home-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "optional": true
     },
     "v8flags": {
       "version": "2.1.1",
-      "resolved": "http://registry.npm.taobao.org/v8flags/download/v8flags-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,14 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "http://registry.npm.taobao.org/anymatch/download/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "arr-diff": {
@@ -34,13 +34,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arr-flatten": "1.0.3"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
-      "version": "1.0.3",
-      "resolved": "http://registry.npm.taobao.org/arr-flatten/download/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true,
       "optional": true
     },
@@ -48,13 +48,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true,
-      "optional": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/arrify/download/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true,
       "optional": true
     },
@@ -66,19 +59,19 @@
       "optional": true
     },
     "babel-cli": {
-      "version": "6.24.1",
-      "resolved": "http://registry.npm.taobao.org/babel-cli/download/babel-cli-6.24.1.tgz",
-      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.25.0",
-        "babel-polyfill": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.9.0",
+        "commander": "2.12.2",
         "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
+        "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "output-file-sync": "1.1.2",
@@ -86,6 +79,180 @@
         "slash": "1.0.0",
         "source-map": "0.5.6",
         "v8flags": "2.1.1"
+      },
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-core": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.8",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "slash": "1.0.0",
+            "source-map": "0.5.6"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+          "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.10.5"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+              "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+              "dev": true
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+              "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+              "dev": true
+            }
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+          "dev": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.1",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.15"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+              "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+              "dev": true
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.8",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -664,6 +831,32 @@
         "regenerator-runtime": "0.10.5"
       }
     },
+    "babel-tape-runner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-tape-runner/-/babel-tape-runner-2.0.1.tgz",
+      "integrity": "sha1-nAEv+asPMAIKwR/MjoSPID8iIXM=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "babel-template": {
       "version": "6.25.0",
       "resolved": "http://registry.npm.taobao.org/babel-template/download/babel-template-6.25.0.tgz",
@@ -719,9 +912,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "http://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
     },
@@ -792,7 +985,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
@@ -803,44 +996,41 @@
       }
     },
     "color": {
-      "version": "1.0.3",
-      "resolved": "http://registry.npm.taobao.org/color/download/color-1.0.3.tgz",
-      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+      "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
       "requires": {
-        "color-convert": "1.9.0",
+        "color-convert": "1.9.1",
         "color-string": "1.5.2"
       }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.2"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.2",
-      "resolved": "http://registry.npm.taobao.org/color-name/download/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
       "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "requires": {
-        "color-name": "1.1.2",
+        "color-name": "1.1.3",
         "simple-swizzle": "0.2.2"
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1032,9 +1222,9 @@
       "dev": true
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npm.taobao.org/fs-readdir-recursive/download/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -1093,12 +1283,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npm.taobao.org/graceful-readlink/download/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "has": {
@@ -1166,13 +1350,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-callable": {
@@ -1262,7 +1446,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -1319,7 +1504,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lodash": {
@@ -1356,7 +1541,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "minimatch": {
@@ -1394,9 +1579,8 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "number-is-nan": {
@@ -1507,8 +1691,8 @@
     },
     "randomatic": {
       "version": "1.1.7",
-      "resolved": "http://registry.npm.taobao.org/randomatic/download/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1518,33 +1702,42 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
             }
           }
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
         }
       }
     },
     "readable-stream": {
-      "version": "2.3.0",
-      "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.0.tgz",
-      "integrity": "sha1-ZA9dzaiMkajcYHhxRWKRcIE6HtI=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1552,8 +1745,8 @@
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.0",
-        "string_decoder": "1.0.2",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
     },
@@ -1566,7 +1759,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.0",
+        "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -1594,14 +1787,13 @@
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "http://registry.npm.taobao.org/regex-cache/download/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -1631,11 +1823,10 @@
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/remove-trailing-separator/download/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true,
-      "optional": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -1675,11 +1866,10 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "http://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.0.tgz",
-      "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
-      "dev": true,
-      "optional": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
@@ -1735,22 +1925,13 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "5.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "http://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true,
-          "optional": true
-        }
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -1791,7 +1972,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=6.0"
   },
   "scripts": {
-    "test": "tape test/*.js | tap-notify | tap-diff",
+    "test": "babel-tape-runner test/*.js | tap-notify | tap-diff",
     "dev": "babel -w ./src --out-dir ./build",
     "build": "babel ./src --out-dir ./build"
   },
@@ -29,6 +29,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-tape-runner": "^2.0.1",
     "blue-tape": "^1.0.0",
     "tape": "^4.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/assuming/gradient-color#readme",
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "blue-tape": "^1.0.0",
     "tape": "^4.6.3"
   },
   "dependencies": {
-    "color": "^1.0.3"
+    "color": "^2.0.1"
   }
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -2,7 +2,7 @@
  * Stupid error collections
  */
 
-exports.NO_EDN_FRAC = new Error('The last element in the color array should not have a frac field')
-exports.MIN_ARRAY_LENGTH = new Error('Color array length must > 1')
-exports.FRAC_SUM_ERROR = new Error('The sum of the fracs should = 1')
-exports.COLOR_NUMBER_ERROR = new Error('The number of generated colors should >= the number of color stops')
+export const NO_EDN_FRAC = new Error('The last element in the color array should not have a frac field')
+export const MIN_ARRAY_LENGTH = new Error('Color array length must > 1')
+export const FRAC_SUM_ERROR = new Error('The sum of the fracs should = 1')
+export const COLOR_NUMBER_ERROR = new Error('The number of generated colors should >= the number of color stops')

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
-const Color = require('color')
-const {
+import Color from 'color'
+import {
   NO_EDN_FRAC,
   MIN_ARRAY_LENGTH,
   FRAC_SUM_ERROR,
-  COLOR_NUMBER_ERROR
-} = require('./errors')
+  COLOR_NUMBER_ERROR,
+} from './errors'
 
 /**
  * Generate n colors with given color stops
- * 
- * @param   {Array}  colorArray 
- * @param   {Number} n          number of colors that need to generate 
+ *
+ * @param   {Array}  colorArray
+ * @param   {Number} n          number of colors that need to generate
  * @returns {Array} array of generated colors in rgb mode
  */
 
@@ -65,12 +65,12 @@ function gradient(colorArray, n) {
  * Explainations:
  * o -> stop color for gradient
  * * -> generated color
- * 
+ *
  * o * * * | o * * * * | o * * o -> generated color list in char version
  *    4          5          4    -> assigned number of colors need to be generated
- * 
+ *
  * The last section, the end color should be considered in the generated colors
- * 
+ *
  * @returns {Array} array of colors in Color(pkg) format, need toString() call
  */
 
@@ -94,13 +94,13 @@ function createGradient(colorList, assignList) {
     const deltaR = (end.red() - start.red()) / num
     const deltaG = (end.green() - start.green()) / num
     const deltaB = (end.blue() - start.blue()) / num
-    
+
     // generate num colors
     for (let i = 0; i < num; i++) {
       const R = start.red() + i * deltaR
       const G = start.green() + i * deltaG
       const B = start.blue() + i * deltaB
-      
+
       list.push(Color.rgb(R, G, B))
     }
 
@@ -108,7 +108,7 @@ function createGradient(colorList, assignList) {
     if (isLastElement) {
       list.push(end)
     }
-    
+
     result = result.concat(list)
   })
 
@@ -117,23 +117,23 @@ function createGradient(colorList, assignList) {
 
 /**
  * Calculate and optimize the number of each color period
- * 
+ *
  * Sometimes frac * N might be a fraction
  * So we use this algorithm:
- * 
+ *
  * 1. Split the number into 2 parts, each part fits in an array:
  * [2, 4, 1, 5]         -> int array
  * [0.2, 0.5, 0.9, 0.3] -> decimal array
- * 
+ *
  * The left number should be:
  * left = N - sum(intArray)
- * 
+ *
  * 2. Sort the decimal array from large to small, assign left to
  * the corresponding element in intArray one by one
  * until left === 0
- * 
+ *
  * 3. There goes your final array!
- * 
+ *
  * @returns {Array} array of optimized color numbers
  */
 
@@ -159,12 +159,12 @@ function assignNumbers(fracList, n) {
 
   // sort O -> o
   decimalArray.sort((a, b) => b.value - a.value)
-  
+
   // assign the left number regard to the decimal part's value
   // until nothing left
   for (let i = 0; i < left; i++) {
     const targetIndex = decimalArray[i].index
-    intArray[targetIndex] = intArray[targetIndex] + 1 
+    intArray[targetIndex] = intArray[targetIndex] + 1
   }
 
   return intArray
@@ -211,4 +211,4 @@ function checkParam(array, n) {
   return result
 }
 
-module.exports = gradient
+export default gradient

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-const test = require('blue-tape')
-const gradient = require('../build/index')
+import test from 'blue-tape'
+import gradient from '../build/index'
 
 
 test('Generated length should be equal', async t => {


### PR DESCRIPTION
Thanks for an excellent package. I had issues with minify (see the explanation in CRE: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify) and therefore changed to ES6-babel as non-es6 features had crept into the build. I also updated the color-package. 

There are plenty of lines changed but that is only duet to the build + trailing spaces